### PR TITLE
Now the background of navMenu will use the theme color rather than th…

### DIFF
--- a/flatly/_overrides.scss
+++ b/flatly/_overrides.scss
@@ -201,6 +201,7 @@ a {
   }
 
   .navbar-menu {
+    background-color: $navbar-background-color;    
     box-shadow: none;
   }
 


### PR DESCRIPTION
Hi, great project! When I adopted the `flatly` theme, it seems that the original `bulma` will override the `navmenu`'s background color to white, which doesn't suit this theme. So I did a tiny change. 

I compiled this project against `bulma 0.5.3` which is different than the `0.5.1` in package.json.