### PR TITLE
Fix theme file extension in getting started section

### DIFF
--- a/help.html
+++ b/help.html
@@ -13,8 +13,8 @@ route: help
         <li>Get started with
           <a href="http://bulma.io/documentation/overview/start/" target="_blank">Bulma</a>
         </li>
-        <li>Download the <code>bulmaswatch.min.scss</code> for the respective theme</li>
-        <li>Replace <code>bulma.css</code> with <code>bulmaswatch.min.scss</code></li>
+        <li>Download the <code>bulmaswatch.min.css</code> for the respective theme</li>
+        <li>Replace <code>bulma.css</code> with <code>bulmaswatch.min.css</code></li>
       </ol>
       <hr>
       <h3 class="title">Use NPM</h3>


### PR DESCRIPTION
For basic usage, the `.min.css` file should be used, not the (non-existent) `.min.scss` file.