### PR TITLE
[Sandstone] Fixing height limit for select multiple

### DIFF
--- a/sandstone/_overrides.scss
+++ b/sandstone/_overrides.scss
@@ -11,8 +11,8 @@
 .pagination-link,
 .pagination-next,
 .pagination-previous,
-.select,
-.select select,
+.select:not(.is-multiple),
+.select:not(.is-multiple) select,
 .textarea {
   height: 2.572em;
 }


### PR DESCRIPTION
Hi,

I found a bug with select and multiple option. The height is limited on select with multiple option, that is illustrated by the first screenshot.
![Select multiple problem](https://user-images.githubusercontent.com/941430/65950018-8ced2300-e43d-11e9-8210-37a4c438e303.png)

I edit the `_overrides.scss` to manage the `select.is-multiple`. I don't know if all cases with multiple is ok.
![Select multiple solution](https://user-images.githubusercontent.com/941430/65950162-cfaefb00-e43d-11e9-8728-615ebeca7a5c.png)

Thanks for reading, and do not hesitate to signal me any problems.
