### PR TITLE
Fix mixed content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bulmaswatch
 ===========
 
-Themes for [Bulma](http://bulma.io), inspired by [Bootswatch](http://bootswatch.com/).
+Themes for [Bulma](https://bulma.io), inspired by [Bootswatch](https://bootswatch.com/).
 
 Get started
 -----
@@ -20,8 +20,8 @@ yarn start
 
 Credits
 -----
-- @jgthms for [Bulma](http://bulma.io)
-- @thomaspark for [Bootswatch](http://bootswatch.com/)
+- @jgthms for [Bulma](https://bulma.io)
+- @thomaspark for [Bootswatch](https://bootswatch.com/)
 
 ## Copyright and License
 

--- a/_includes/components/level.html
+++ b/_includes/components/level.html
@@ -73,7 +73,7 @@
     <p class="level-item has-text-centered">
       <a class="link is-info">Menu</a>
     </p>
-    <p class="level-item has-text-centered"> <img src="http://bulma.io/images/bulma-type.png" alt="" style="height: 30px;"> </p>
+    <p class="level-item has-text-centered"> <img src="https://bulma.io/images/bulma-type.png" alt="" style="height: 30px;"> </p>
     <p class="level-item has-text-centered">
       <a class="link is-info">Reservations</a>
     </p>

--- a/_includes/components/media.html
+++ b/_includes/components/media.html
@@ -81,7 +81,7 @@
       <article class="media">
         <figure class="media-left">
           <p class="image is-48x48">
-            <img src="http://bulma.io/images/placeholders/96x96.png">
+            <img src="https://bulma.io/images/placeholders/96x96.png">
           </p>
         </figure>
         <div class="media-content">
@@ -104,7 +104,7 @@
       <article class="media">
         <figure class="media-left">
           <p class="image is-48x48">
-            <img src="http://bulma.io/images/placeholders/96x96.png">
+            <img src="https://bulma.io/images/placeholders/96x96.png">
           </p>
         </figure>
         <div class="media-content">

--- a/_includes/components/navbar.html
+++ b/_includes/components/navbar.html
@@ -5,7 +5,7 @@
   <nav class="navbar {% if m != '' %}is-{{m}}{% endif %}">
     <div class="navbar-brand">
       <a class="navbar-item" href="http://bulma.io">
-        <img src="http://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28">
+        <img src="https://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28">
       </a>
       <a class="navbar-item is-hidden-desktop" href="https://github.com/jgthms/bulma" target="_blank">
         <span class="icon" style="color: #333;">
@@ -172,7 +172,7 @@
   <nav class="navbar is-transparent">
     <div class="navbar-brand">
       <a class="navbar-item" href="http://bulma.io">
-        <img src="http://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28">
+        <img src="https://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28">
       </a>
       <a class="navbar-item is-hidden-desktop" href="https://github.com/jgthms/bulma" target="_blank">
         <span class="icon" style="color: #333;">

--- a/_includes/components/navbar.html
+++ b/_includes/components/navbar.html
@@ -4,7 +4,7 @@
   {% for m in page.modifiers %}
   <nav class="navbar {% if m != '' %}is-{{m}}{% endif %}">
     <div class="navbar-brand">
-      <a class="navbar-item" href="http://bulma.io">
+      <a class="navbar-item" href="https://bulma.io">
         <img src="https://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28">
       </a>
       <a class="navbar-item is-hidden-desktop" href="https://github.com/jgthms/bulma" target="_blank">
@@ -171,7 +171,7 @@
   <h2 class="subtitle">Transparent</h2>
   <nav class="navbar is-transparent">
     <div class="navbar-brand">
-      <a class="navbar-item" href="http://bulma.io">
+      <a class="navbar-item" href="https://bulma.io">
         <img src="https://bulma.io/images/bulma-logo.png" alt="Bulma: a modern CSS framework based on Flexbox" width="112" height="28">
       </a>
       <a class="navbar-item is-hidden-desktop" href="https://github.com/jgthms/bulma" target="_blank">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,13 +12,13 @@
       </p>
       <p>
         <strong>Bulmaswatch</strong> by
-        <a href="http://jgog.in" target="_blank">Jenil Gogari</a>.
+        <a href="https://jgog.in" target="_blank">Jenil Gogari</a>.
         <br> Based on
-        <a href="http://bulma.io" target="_blank" onclick="ga('send', 'event', 'footer', 'click', 'bulma');">Bulma</a>. Icons from
-        <a href="http://fontawesome.io/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', 'font-awesome');">Font Awesome</a>. Web Fonts from
+        <a href="https://bulma.io" target="_blank" onclick="ga('send', 'event', 'footer', 'click', 'bulma');">Bulma</a>. Icons from
+        <a href="https://fontawesome.com/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', 'font-awesome');">Font Awesome</a>. Web Fonts from
         <a href="https://fonts.google.com/" target="_blank" onclick="ga('send', 'event', 'footer', 'click', 'google');">Google</a>.
         <br> The source code is licensed
-        <a href="http://opensource.org/licenses/mit-license.php" target="_blank">MIT</a>.
+        <a href="https://opensource.org/licenses/mit-license.php" target="_blank">MIT</a>.
       </p>
       <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
         <input type="hidden" name="cmd" value="_s-xclick">

--- a/help.html
+++ b/help.html
@@ -11,7 +11,7 @@ route: help
       <h3 class="title">Getting started</h3>
       <ol>
         <li>Get started with
-          <a href="http://bulma.io/documentation/overview/start/" target="_blank">Bulma</a>
+          <a href="https://bulma.io/documentation/overview/start/" target="_blank">Bulma</a>
         </li>
         <li>Download the <code>bulmaswatch.min.css</code> for the respective theme</li>
         <li>Replace <code>bulma.css</code> with <code>bulmaswatch.min.css</code></li>


### PR DESCRIPTION
On [the preview pages](https://jenil.github.io/bulmaswatch/default/), some images from bulma.io are loaded over http which results in mixed content warnings.

This changes images and links to use https.